### PR TITLE
Add find_closest_country expression that return country code

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,24 +15,31 @@ pip install polars-reverse-geocode
 ```python
 import polars as pl
 
-from polars_reverse_geocode import find_closest_city
+from polars_reverse_geocode import find_closest_city, find_closest_state, find_closest_country
 
 df = pl.DataFrame({
     'lat': [37.7749, 51.01, 52.5],
     'lon': [-122.4194, -3.9, -.91]
 })
-print(df.with_columns(city=find_closest_city('lat', 'lon')))
+
+print(
+    df.with_columns(
+        city = find_closest_city('lat', 'lon'),
+        state = find_closest_state('lat', 'lon'),
+        country_code = find_closest_country('lat', 'lon')
+    )
+)
 ```
 
 ```
-shape: (3, 3)
-┌─────────┬───────────┬───────────────────┐
-│ lat     ┆ lon       ┆ city              │
-│ ---     ┆ ---       ┆ ---               │
-│ f64     ┆ f64       ┆ str               │
-╞═════════╪═══════════╪═══════════════════╡
-│ 37.7749 ┆ -122.4194 ┆ San Francisco     │
-│ 51.01   ┆ -3.9      ┆ South Molton      │
-│ 52.5    ┆ -0.91     ┆ Market Harborough │
-└─────────┴───────────┴───────────────────┘
+shape: (3, 5)
+┌─────────┬───────────┬───────────────────┬────────────┬──────────────┐
+│ lat     ┆ lon       ┆ city              ┆ state      ┆ country_code │
+│ ---     ┆ ---       ┆ ---               ┆ ---        ┆ ---          │
+│ f64     ┆ f64       ┆ str               ┆ str        ┆ str          │
+╞═════════╪═══════════╪═══════════════════╪════════════╪══════════════╡
+│ 37.7749 ┆ -122.4194 ┆ San Francisco     ┆ California ┆ US           │
+│ 51.01   ┆ -3.9      ┆ South Molton      ┆ England    ┆ GB           │
+│ 52.5    ┆ -0.91     ┆ Market Harborough ┆ England    ┆ GB           │
+└─────────┴───────────┴───────────────────┴────────────┴──────────────┘
 ```

--- a/polars_reverse_geocode/__init__.py
+++ b/polars_reverse_geocode/__init__.py
@@ -35,3 +35,11 @@ def find_closest_state(lat: IntoExpr, long: IntoExpr) -> pl.Expr:
         function_name="find_closest_state",
         is_elementwise=True,
     )
+
+def find_closest_country(lat: IntoExpr, long: IntoExpr) -> pl.Expr:
+    return register_plugin_function(
+        args=[lat, long],
+        plugin_path=LIB,
+        function_name="find_closest_country",
+        is_elementwise=True,
+    )

--- a/polars_reverse_geocode/__init__.py
+++ b/polars_reverse_geocode/__init__.py
@@ -36,6 +36,7 @@ def find_closest_state(lat: IntoExpr, long: IntoExpr) -> pl.Expr:
         is_elementwise=True,
     )
 
+
 def find_closest_country(lat: IntoExpr, long: IntoExpr) -> pl.Expr:
     return register_plugin_function(
         args=[lat, long],

--- a/polars_reverse_geocode/__init__.py
+++ b/polars_reverse_geocode/__init__.py
@@ -19,7 +19,7 @@ def find_closest_city(lat: IntoExpr, long: IntoExpr) -> pl.Expr:
     return register_plugin_function(
         args=[lat, long],
         plugin_path=LIB,
-        function_name="reverse_geocode",
+        function_name="find_closest_city",
         is_elementwise=True,
     )
 

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -13,10 +13,7 @@ enum LocationLevel {
     Country,
 }
 
-fn reverse_geocode_chunks(
-    inputs: &[Series],
-    location_level: LocationLevel,
-) -> PolarsResult<Series> {
+fn reverse_geocode(inputs: &[Series], location_level: LocationLevel) -> PolarsResult<Series> {
     let lhs = inputs[0].f64()?;
     let rhs = inputs[1].f64()?;
     let geocoder = ReverseGeocoder::new();
@@ -35,15 +32,15 @@ fn reverse_geocode_chunks(
 
 #[polars_expr(output_type=String)]
 fn find_closest_city(inputs: &[Series]) -> PolarsResult<Series> {
-    reverse_geocode_chunks(inputs, LocationLevel::City)
+    reverse_geocode(inputs, LocationLevel::City)
 }
 
 #[polars_expr(output_type=String)]
 fn find_closest_state(inputs: &[Series]) -> PolarsResult<Series> {
-    reverse_geocode_chunks(inputs, LocationLevel::State)
+    reverse_geocode(inputs, LocationLevel::State)
 }
 
 #[polars_expr(output_type=String)]
 fn find_closest_country(inputs: &[Series]) -> PolarsResult<Series> {
-    reverse_geocode_chunks(inputs, LocationLevel::Country)
+    reverse_geocode(inputs, LocationLevel::Country)
 }

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::unused_unit)]
 use polars::prelude::*;
-use polars_arrow::array::MutablePlString;
-use polars_core::utils::align_chunks_binary;
+use polars_core::prelude::arity::binary_elementwise_into_string_amortized;
 use pyo3_polars::derive::polars_expr;
 use std::fmt::Write;
 
@@ -22,35 +21,15 @@ fn reverse_geocode_chunks(
     let rhs = inputs[1].f64()?;
     let geocoder = ReverseGeocoder::new();
 
-    let (lhs, rhs) = align_chunks_binary(lhs, rhs);
-    let chunks = lhs
-        .downcast_iter()
-        .zip(rhs.downcast_iter())
-        .map(|(lhs_arr, rhs_arr)| {
-            let mut buf = String::new();
-            let mut mutarr = MutablePlString::with_capacity(lhs_arr.len());
-
-            for (lhs_opt_val, rhs_opt_val) in lhs_arr.iter().zip(rhs_arr.iter()) {
-                match (lhs_opt_val, rhs_opt_val) {
-                    (Some(lhs_val), Some(rhs_val)) => {
-                        let record = &geocoder.search((*lhs_val, *rhs_val)).record;
-                        let res: &String = match location_level {
-                            LocationLevel::City => &record.name,
-                            LocationLevel::State => &record.admin1,
-                            LocationLevel::Country => &record.cc,
-                        };
-                        buf.clear();
-                        write!(buf, "{res}").unwrap();
-                        mutarr.push(Some(&buf))
-                    }
-                    _ => mutarr.push_null(),
-                }
-            }
-
-            mutarr.freeze().boxed()
-        })
-        .collect();
-    let out: StringChunked = unsafe { ChunkedArray::from_chunks(PlSmallStr::EMPTY, chunks) };
+    let out = binary_elementwise_into_string_amortized(lhs, rhs, |lat, lon, buf| {
+        let record = geocoder.search((lat, lon)).record;
+        let res: &String = match location_level {
+            LocationLevel::City => &record.name,
+            LocationLevel::State => &record.admin1,
+            LocationLevel::Country => &record.cc,
+        };
+        write!(buf, "{}", res).unwrap();
+    });
     Ok(out.into_series())
 }
 

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -1,25 +1,23 @@
 #![allow(clippy::unused_unit)]
 use polars::prelude::*;
 use polars_arrow::array::MutablePlString;
-use polars_core::prelude::arity::binary_elementwise_into_string_amortized;
 use polars_core::utils::align_chunks_binary;
 use pyo3_polars::derive::polars_expr;
 use std::fmt::Write;
 
 use reverse_geocoder::ReverseGeocoder;
 
-#[polars_expr(output_type=String)]
-fn reverse_geocode(inputs: &[Series]) -> PolarsResult<Series> {
-    let lhs = inputs[0].f64()?;
-    let rhs = inputs[1].f64()?;
-    let geocoder = ReverseGeocoder::new();
-    let out = binary_elementwise_into_string_amortized(lhs, rhs, |lat, lon, buf| {
-        write!(buf, "{}", geocoder.search((lat, lon)).record.name).unwrap();
-    });
-    Ok(out.into_series())
+#[derive(PartialEq, Eq)]
+enum LocationLevel {
+    City,
+    State,
+    Country,
 }
 
-fn reverse_geocode_chunks(inputs: &[Series], return_type: String) -> PolarsResult<Series> {
+fn reverse_geocode_chunks(
+    inputs: &[Series],
+    location_level: LocationLevel,
+) -> PolarsResult<Series> {
     let lhs = inputs[0].f64()?;
     let rhs = inputs[1].f64()?;
     let geocoder = ReverseGeocoder::new();
@@ -36,16 +34,11 @@ fn reverse_geocode_chunks(inputs: &[Series], return_type: String) -> PolarsResul
                 match (lhs_opt_val, rhs_opt_val) {
                     (Some(lhs_val), Some(rhs_val)) => {
                         let record = &geocoder.search((*lhs_val, *rhs_val)).record;
-                        let res: &String;
-                        if return_type == "city" {
-                            res = &record.name;
-                        } else if return_type == "state" {
-                            res = &record.admin1;
-                        } else if return_type == "country" {
-                            res = &record.cc;
-                        } else {
-                            res = &record.name;
-                        }
+                        let res: &String = match location_level {
+                            LocationLevel::City => &record.name,
+                            LocationLevel::State => &record.admin1,
+                            LocationLevel::Country => &record.cc,
+                        };
                         buf.clear();
                         write!(buf, "{res}").unwrap();
                         mutarr.push(Some(&buf))
@@ -62,11 +55,16 @@ fn reverse_geocode_chunks(inputs: &[Series], return_type: String) -> PolarsResul
 }
 
 #[polars_expr(output_type=String)]
+fn find_closest_city(inputs: &[Series]) -> PolarsResult<Series> {
+    reverse_geocode_chunks(inputs, LocationLevel::City)
+}
+
+#[polars_expr(output_type=String)]
 fn find_closest_state(inputs: &[Series]) -> PolarsResult<Series> {
-    reverse_geocode_chunks(inputs, "state".to_string())
+    reverse_geocode_chunks(inputs, LocationLevel::State)
 }
 
 #[polars_expr(output_type=String)]
 fn find_closest_country(inputs: &[Series]) -> PolarsResult<Series> {
-    reverse_geocode_chunks(inputs, "country".to_string())
+    reverse_geocode_chunks(inputs, LocationLevel::Country)
 }

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -63,10 +63,10 @@ fn reverse_geocode_chunks(inputs: &[Series], return_type: String) -> PolarsResul
 
 #[polars_expr(output_type=String)]
 fn find_closest_state(inputs: &[Series]) -> PolarsResult<Series> {
-    return reverse_geocode_chunks(inputs, "state".to_string());
+    reverse_geocode_chunks(inputs, "state".to_string())
 }
 
 #[polars_expr(output_type=String)]
 fn find_closest_country(inputs: &[Series]) -> PolarsResult<Series> {
-    return reverse_geocode_chunks(inputs, "country".to_string());
+    reverse_geocode_chunks(inputs, "country".to_string())
 }

--- a/t.py
+++ b/t.py
@@ -1,9 +1,16 @@
 import polars as pl
 
-from polars_reverse_geocode import find_closest_city
+from polars_reverse_geocode import find_closest_city, find_closest_state, find_closest_country
 
 df = pl.DataFrame({
     'lat': [37.7749, 51.01, 52.5],
     'lon': [-122.4194, -3.9, -.91]
 })
-print(df.with_columns(city = find_closest_city('lat', 'lon')))
+
+print(
+    df.with_columns(
+        city = find_closest_city('lat', 'lon'),
+        state = find_closest_state('lat', 'lon'),
+        country_code = find_closest_country('lat', 'lon')
+    )
+)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,11 @@
 import polars as pl
 from polars.testing import assert_frame_equal
 
-from polars_reverse_geocode import reverse_geocode, find_closest_state, find_closest_country
+from polars_reverse_geocode import (
+    reverse_geocode,
+    find_closest_state,
+    find_closest_country,
+)
 
 
 def test_main() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,7 @@
 import polars as pl
 from polars.testing import assert_frame_equal
 
-from polars_reverse_geocode import reverse_geocode, find_closest_state
+from polars_reverse_geocode import reverse_geocode, find_closest_state, find_closest_country
 
 
 def test_main() -> None:
@@ -25,6 +25,19 @@ def test_find_closest_state() -> None:
             "lat": [37.7749, 51.01, 52.5],
             "lon": [-122.4194, -3.9, -0.91],
             "city": ["California", "England", "England"],
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
+def test_find_closest_country() -> None:
+    df = pl.DataFrame({"lat": [37.7749, 51.01, 52.5], "lon": [-122.4194, -3.9, -0.91]})
+    result = df.with_columns(city=find_closest_country("lat", "lon"))
+    expected = pl.DataFrame(
+        {
+            "lat": [37.7749, 51.01, 52.5],
+            "lon": [-122.4194, -3.9, -0.91],
+            "city": ["US", "GB", "GB"],
         }
     )
     assert_frame_equal(result, expected)


### PR DESCRIPTION
## Description
This PR adds new 'find_closest_country' polars expression that allows resolving geo points into country codes.

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation
I need a quick and efficient way to resolve points in polars df into country codes.

## Implementation Details
Since ReverseGeocoder already returns Record object with city, state and country, all we need to do is to specify desired output and get the appropriate field from Record object.

## Testing
- added new test that runs 'find_closest_country' expression
- all tests passed

## Checklist
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature
- [x] My changes generate no new warnings
- [x] Documentation is updated (if applicable)

## Potential Future Improvements
- Resolve 2-letter country codes into 3-letter country codes and official country names, as per ISO standards. Add argument to specify desired output in 'find_closest_country' expression.